### PR TITLE
#162132648 Add a page for displaying number of resolved/unresolved/rejected records

### DIFF
--- a/UI/css/styles.css
+++ b/UI/css/styles.css
@@ -729,3 +729,65 @@ select{
   display: block;
   text-align: center;
 }
+
+
+/* STATS SECTION STYLES */
+
+.stats-content {
+  flex: 1;
+  margin-top: 2em;
+  margin-bottom: 3em;
+  padding: 2em;
+}
+
+.stats-main {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.stats-main table {
+  border-collapse: separate;
+  border-spacing: 0;
+  color: #4a4a4d;
+  font: sans-serif;
+  font-size: 1.5em;
+}
+.stats-main th,
+.stats-main td {
+  padding: 0.8em 1.2em;
+  vertical-align: middle;
+}
+.stats-main thead {
+  background: #395870;
+  background: linear-gradient(#49708f, #293f50);
+  color: #fff;
+  font-size: 0.8em;
+  text-transform: uppercase;
+}
+
+.stats-main tbody tr:nth-child(even) {
+  background: #f0f0f2;
+}
+.stats-main td {
+  border-bottom: 1px solid #cecfd5;
+  border-right: 1px solid #cecfd5;
+}
+.stats-main td:first-child {
+  border-left: 1px solid #cecfd5;
+}
+.record-title {
+  color: #395870;
+  display: block;
+  font-size: 0.9em;
+}
+
+.resolved,
+.not-resolved,
+.rejected {
+  text-align: center;
+}
+
+.stats-main tbody {
+  text-align: right;
+}

--- a/UI/stats.html
+++ b/UI/stats.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>Stats - iReporter</title>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, scale=1">
+	<link rel="stylesheet" type="text/css" href="css/styles.css">
+</head>
+
+<body>
+	<header class="header">
+		<div class="container top-nav">
+			<nav>
+				<ul class="header-nav nav-links">
+					<li><a href="home.html">Home</a></li>
+					<li><a href="stats.html">Stats</a></li>
+					<li><a href="profile.html">Profile</a></li>
+					<li><a href="create-record.html" class="tagged btn-nav">Add Record</a></li>
+					<li><a href="#">Sign out</a></li>
+				</ul>
+			</nav>
+			<a href="index.html" class="logo">
+				iReporter
+			</a>
+		</div>
+	</header>
+
+	<section class="stats-content">
+		<div class="container">
+			<div class="stats-main">
+				<table>
+				  <thead>
+				    <tr>
+				      <th scope="col">Record Type</th>
+				      <th scope="col">Resolved</th>
+				      <th scope="col">Under Investigation</th>
+				      <th scope="col">rejected</th>
+				    </tr>
+				  </thead>
+				  <tbody>
+				    <tr>
+				      <td>
+				        <strong class="record-title">Red-Flag</strong>
+				      </td>
+				      <td class="resolved">0</td>
+				      <td class="not-resolved">0</td>
+				      <td class="rejected">0</td>
+				    </tr>
+
+				    <tr>
+				      <td>
+				        <strong class="record-title">Intervention</strong>
+				      </td>
+				      <td class="resolved">0</td>
+				      <td class="not-resolved">0</td>
+				      <td class="rejected">0</td>
+				    </tr>
+
+				    <tr>
+				      <td>
+				        <strong class="record-title">Total</strong>
+				      </td>
+				      <td class="resolved">0</td>
+				      <td class="not-resolved">0</td>
+				      <td class="rejected">0</td>
+				    </tr>
+
+				    <tr>
+				      <td>
+				        <strong class="record-title">All Records</strong>
+				      </td>
+				     <td colspan="3">0</td>
+				    </tr>
+
+				  </tbody>
+	
+				</table>
+			</div>			
+
+		</div>
+	</section>
+
+
+	<footer class="footer">
+	  <div class="container">
+	    <p>&copy; 2018 iReporter.</p>
+	  </div>
+	</footer>
+
+</body>
+
+</html>

--- a/home.html
+++ b/home.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>Home - iReporter</title>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, scale=1">
+	<link rel="stylesheet" type="text/css" href="css/styles.css">
+</head>
+
+<body>
+	<header class="header">
+		<div class="container top-nav">
+			<nav>
+				<ul class="header-nav nav-links">
+					<li><a href="home.html">Home</a></li>
+					<li><a href="stats.html">Stats</a></li>
+					<li><a href="profile.html">Profile</a></li>
+					<li><a href="#" class="tagged btn-nav">Add Record</a></li>
+					<li><a href="#">Sign out</a></li>
+				</ul>
+			</nav>
+			<a href="index.html" class="logo">
+				iReporter
+			</a>
+		</div>
+	</header>
+
+	<section class="home-section">
+		<div class="container">
+			<div class="profile-body">
+
+				<div class="feed-header">
+					<div class="feed-tags">
+						<ul>
+							<li class="non-tag">Red Flag</li>
+							<li class="non-tag">Intervention</li>
+						</ul>
+					</div>
+					<h2 class="list-header">Feed</h2>
+				</div>
+
+				<div class="feed-body">
+
+					<div class="feed-item">
+						<table>
+							<tr>
+								<td width="40px">
+									<img src="https://www.gravatar.com/avatar/d78e11f95e127af880e35e91a5cb0362?d=identicon&amp;s=120" class="user-photo" alt="profile photo">
+									
+								</td>
+								<td>
+									<div class="user">
+										<a href="profile.html" >Username</a>
+										<p>posted 2 days ago</p>
+									</div>
+									
+								</td>
+							</tr>
+						</table>
+
+						<div class="description">
+							<p>Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum</p>
+
+						</div>
+
+						<div class="feed-footer feed-tags">
+							<ul>
+								<li class="red-flag">Red Flag</li>
+								<li class="non-tag"><a href="">Location</a></li>
+								<li class="non-tag edit"><a href="">Edit</a></li>
+								<li class="non-tag delete"><a href="">Delete</a></li>
+								<li class="resolved">Resolved</li>
+							</ul>
+						</div>
+					</div>
+
+					<div class="feed-item">
+						<table>
+							<tr>
+								<td width="40px">
+									<img src="https://www.gravatar.com/avatar/d78e11f95e127af880e35e91a5cb0362?d=identicon&amp;s=120" class="user-photo" alt="profile photo">
+									
+								</td>
+								<td>
+									<div class="user">
+										<a href="profile.html" >Username</a>
+										<p>posted 2 days ago</p>
+									</div>
+									
+								</td>
+							</tr>
+						</table>
+
+						<div class="description">
+							<p>Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum</p>
+
+						</div>
+
+						<div class="feed-footer feed-tags">
+							<ul>
+								<li class="intervention">Intervention</li>
+								<li class="non-tag"><a href="">Location</a></li>
+								<li class="non-tag edit"><a href="">Edit</a></li>
+								<li class="non-tag delete"><a href="">Delete</a></li>
+								<li class="unresolved">Unresolved</li>
+							</ul>
+						</div>
+					</div>	
+
+					<div class="feed-item">
+						<table>
+							<tr>
+								<td width="40px">
+									<img src="https://www.gravatar.com/avatar/d78e11f95e127af880e35e91a5cb0362?d=identicon&amp;s=120" class="user-photo" alt="profile photo">
+									
+								</td>
+								<td>
+									<div class="user">
+										<a href="profile.html" >Username</a>
+										<p>posted 2 days ago</p>
+									</div>
+									
+								</td>
+							</tr>
+						</table>
+
+						<div class="description">
+							<p>Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum</p>
+
+						</div>
+
+						<div class="feed-footer feed-tags">
+							<ul>
+								<li class="red-flag">Red Flag</li>
+								<li class="non-tag"><a href="">Location</a></li>
+								<li class="non-tag edit"><a href="">Edit</a></li>
+								<li class="non-tag delete"><a href="">Delete</a></li>
+								<li class="rejected">Rejected</li>
+							</ul>
+						</div>
+					</div>	
+
+					<div class="feed-item">
+						<table>
+							<tr>
+								<td width="40px">
+									<img src="https://www.gravatar.com/avatar/d78e11f95e127af880e35e91a5cb0362?d=identicon&amp;s=120" class="user-photo" alt="profile photo">
+									
+								</td>
+								<td>
+									<div class="user">
+										<a href="profile.html" >Username</a>
+										<p>posted 2 days ago</p>
+									</div>
+								</td>
+							</tr>
+						</table>
+
+						<div class="description">
+							<p>Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum</p>
+
+						</div>
+
+						<div class="feed-footer feed-tags">
+							<ul>
+								<li class="intervention">Intervention</li>
+								<li class="non-tag"><a href="">Location</a></li>
+								<li class="non-tag edit"><a href="">Edit</a></li>
+								<li class="non-tag delete"><a href="">Delete</a></li>
+								<li class="resolved">Resolved</li>
+							</ul>
+						</div>
+					</div>	
+
+					<div class="feed-item">
+						<table>
+							<tr>
+								<td width="40px">
+									<img src="https://www.gravatar.com/avatar/d78e11f95e127af880e35e91a5cb0362?d=identicon&amp;s=120" class="user-photo" alt="profile photo">
+									
+								</td>
+								<td>
+									<div class="user">
+										<a href="profile.html" >Username</a>
+										<p>posted 2 days ago</p>
+									</div>
+									
+								</td>
+							</tr>
+						</table>
+
+						<div class="description">
+							<p>Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum</p>
+
+						</div>
+
+						<div class="feed-footer feed-tags">
+							<ul>
+								<li class="red-flag">Red Flag</li>
+								<li class="non-tag"><a href="">Location</a></li>
+								<li class="non-tag edit"><a href="">Edit</a></li>
+								<li class="non-tag delete"><a href="">Delete</a></li>
+								<li class="unresolved">Unresolved</li>
+							</ul>
+						</div>
+					</div>	
+
+					<div class="feeder-nav">
+						<a href="" class="feeder-nav-btn disabled">Previous</a>
+						<a href="" class="feeder-nav-btn shift-right disabled">Next</a>
+					</div>				
+				</div>
+			</div>
+		</div>
+	</section>
+	
+	<footer class="footer">
+	  <div class="container">
+	    <p>&copy; 2018 iReporter.</p>
+	  </div>
+	</footer>
+
+</body>
+
+</html>


### PR DESCRIPTION
#### What does this PR do?
Build a stats page that displays the number of resolved, unresolved(in draft/under investigation) and rejected red-flag/intervention records

#### Description of Task to be completed?
Display a statistics page with the number of resolved, unresolved(in draft/under investigation) and rejected red-flag/intervention records. The data is filled in a clearly formatted table.

#### How should this be manually tested?
Clone the repo, checkout the ft-statistics-page-#162132648 and use your favorite browser to open the stats.html file

#### Any background context you want to provide?
The stats page is only a mock up. It is a static page with no back-end functionality implemented

#### What are the relevant pivotal tracker stories?
#162132648

#### Screenshots (if appropriate)

![stats](https://user-images.githubusercontent.com/10455781/49011393-4aa4e680-f187-11e8-99eb-aa3749c55310.png)
