### PR TITLE
#162407900 Fix POST/PATCH endpoints

### DIFF
--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -115,7 +115,7 @@ class UpdateSingleRedflag(Resource):
         Record.put(record)
         output = {}
         output['status'] = 200
-        output['data'] = [{"id": _id, "message": "Updated red-flag record's " + field}]
+        output['data'] = [{"id": _id, "message": field + ' has been successfully updated'}]
         return output, 200
 #
 # API resource routing

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -41,7 +41,7 @@ class CreateOrReturnRedflags(Resource):
         record.add_field('uri', uri)
         Record.put(record)
         output = {'status': 201,
-                  'data': [{"id": record.data_id, "message": "Created a red-flag record"}]
+                  'data': [record.serialize]
                  }
 
         return output, 201, {'Location': uri}

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -10,7 +10,7 @@ from . import api_bp
 from .models import Record
 from .errors import raise_error
 
-class RedflagListAPI(Resource):
+class CreateOrReturnRedflags(Resource):
     """
     Implements methods for creating a record and returning a collection
     of records.
@@ -20,7 +20,7 @@ class RedflagListAPI(Resource):
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('comment', type=str, required=True, help='comment not provided')
         self.parser.add_argument('location', type=str, required=True, help='location not provided')
-        super(RedflagListAPI, self).__init__()
+        super(CreateOrReturnRedflags, self).__init__()
 
     def get(self):
         """
@@ -46,7 +46,7 @@ class RedflagListAPI(Resource):
 
         return output, 201, {'Location': uri}
 
-class RedflagAPI(Resource):
+class SingleRedflag(Resource):
     """
     Implements methods for manipulating a particular record
     """
@@ -83,7 +83,7 @@ class RedflagAPI(Resource):
         out['data'] = [{'id':_id, 'message': 'red-flag record deleted'}]
         return out
 
-class RedflagUpdateAPI(Resource):
+class UpdateSingleRedflag(Resource):
     """
     Updates the location or comment field of red-flag record
     """
@@ -91,7 +91,7 @@ class RedflagUpdateAPI(Resource):
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('comment', type=str)
         self.parser.add_argument('location', type=str)
-        super(RedflagUpdateAPI, self).__init__()
+        super(UpdateSingleRedflag, self).__init__()
 
     def patch(self, _id, field):
         """
@@ -121,6 +121,6 @@ class RedflagUpdateAPI(Resource):
 # API resource routing
 #
 
-api_bp.add_resource(RedflagListAPI, '/red-flags', endpoint='redflags')
-api_bp.add_resource(RedflagAPI, '/red-flags/<_id>', endpoint='redflag')
-api_bp.add_resource(RedflagUpdateAPI, '/red-flags/<_id>/<field>', endpoint='update_redflag')
+api_bp.add_resource(CreateOrReturnRedflags, '/red-flags', endpoint='redflags')
+api_bp.add_resource(SingleRedflag, '/red-flags/<_id>', endpoint='redflag')
+api_bp.add_resource(UpdateSingleRedflag, '/red-flags/<_id>/<field>', endpoint='update_redflag')

--- a/app/tests/v1/test_views.py
+++ b/app/tests/v1/test_views.py
@@ -91,12 +91,23 @@ def test_get_one(client):
     assert resp.headers['Content-Type'] == 'application/json'
     assert b'data' in resp.data
     assert b'status' in resp.data
-    # Item not found
+    # Check that returned data has all fields and contains user input data
+    data = json.loads(resp.data.decode('utf-8'))
+    data = data['data'][0] # Returns a dictionary of data item
+    assert data.get('location') == '-1.23, 36.5'
+    assert data.get('comment') == 'crooked tendering processes'
+    assert type(data.get('type')) == str
+    assert type(data.get('status')) == str
+    assert type(data.get('createdBy')) == int
+    assert type(data.get('id')) == int
+    assert type(data.get('Images')) == list 
+    assert type(data.get('Videos')) == list 
+    # Item not found - ID out of range
     resp = client.get('/api/v1/red-flags/999')
     assert resp.status_code == 404
     assert resp.headers['Content-Type'] == 'application/json'
     # Invalid ID
-    resp = client.get('/api/v1/red-flags/data-id')
+    resp = client.get('/api/v1/red-flags/some-id')
     assert resp.status_code == 404
     assert resp.headers['Content-Type'] == 'application/json'
 

--- a/app/tests/v1/test_views.py
+++ b/app/tests/v1/test_views.py
@@ -8,6 +8,7 @@
 from app import create_app
 from instance.config import TestConfig
 from app.api.v1.models import Record as db
+from datetime import datetime
 import pytest
 import json
 
@@ -58,8 +59,17 @@ def test_post(client):
     assert resp.status_code == 201
     assert b'data' in resp.data
     assert b'status' in resp.data
+    # Check that returned data has all fields and contains user input data
     data = json.loads(resp.data.decode('utf-8'))
-    assert 'red-flag record' in data['data'][0]['message']
+    data = data['data'][0] # Returns a dictionary of data item
+    assert data.get('location') == '-1.23, 36.5'
+    assert data.get('comment') == 'crooked tendering processes'
+    assert type(data.get('type')) == str
+    assert type(data.get('status')) == str
+    assert type(data.get('createdBy')) == int
+    assert type(data.get('id')) == int
+    assert type(data.get('Images')) == list 
+    assert type(data.get('Videos')) == list 
     assert resp.mimetype == 'application/json'
     assert resp.headers['Location'] is not None
     # Missing fields in request
@@ -69,6 +79,7 @@ def test_post(client):
     assert resp.status_code ==  400
     resp = client.post('/api/v1/red-flags', data=None)
     assert resp.status_code ==  400
+
 
 def test_get_one(client):
     resp = client.post('/api/v1/red-flags', data=user_input)

--- a/app/tests/v1/test_views.py
+++ b/app/tests/v1/test_views.py
@@ -12,7 +12,6 @@ from datetime import datetime
 import pytest
 import json
 
-
 @pytest.fixture
 def client():
     """
@@ -42,7 +41,6 @@ def test_get_all(client):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode('utf-8'))
     assert len(data['data']) == 0
-
     resp = client.post('/api/v1/red-flags', data=user_input)
     resp = client.get('/api/v1/red-flags')
     assert resp.status_code == 200
@@ -50,6 +48,16 @@ def test_get_all(client):
     assert b'status' in resp.data
     data = json.loads(resp.data.decode('utf-8'))
     assert len(data['data']) == 1
+    data = json.loads(resp.data.decode('utf-8'))
+    data = data['data'][0] # Returns a dictionary of data item
+    assert data.get('location') == '-1.23, 36.5'
+    assert data.get('comment') == 'crooked tendering processes'
+    assert type(data.get('type')) == str
+    assert type(data.get('status')) == str
+    assert type(data.get('createdBy')) == int
+    assert type(data.get('id')) == int
+    assert type(data.get('Images')) == list 
+    assert type(data.get('Videos')) == list 
 
 def test_post(client):
     """
@@ -109,7 +117,6 @@ def test_get_one(client):
     resp = client.get('/api/v1/red-flags/some-id')
     assert resp.status_code == 404
     assert resp.headers['Content-Type'] == 'application/json'
-
 
 def test_delete_one(client):
     # create a red-flag to use for testing deletion

--- a/app/tests/v1/test_views.py
+++ b/app/tests/v1/test_views.py
@@ -80,7 +80,6 @@ def test_post(client):
     resp = client.post('/api/v1/red-flags', data=None)
     assert resp.status_code ==  400
 
-
 def test_get_one(client):
     resp = client.post('/api/v1/red-flags', data=user_input)
     assert resp.status_code == 201
@@ -136,7 +135,7 @@ def test_delete_one(client):
     assert resp.status_code == 404
     assert resp.headers['Content-Type'] == 'application/json'
 
-def test_patch_location_and_comment(client):
+def test_patch_location_or_comment(client):
     def update_field(field):
         resp = client.post('/api/v1/red-flags', data=user_input)
         assert resp.status_code == 201
@@ -153,7 +152,7 @@ def test_patch_location_and_comment(client):
         assert b'data' in resp.data
         assert b'status' in  resp.data
         data = json.loads(resp.data.decode('utf-8'))
-        assert 'Updated' in data['data'][0]['message']
+        assert data['data'][0]['message'] == field + ' has been successfully updated'
         # Item not present
         resp = client.patch('/api/v1/red-flags/10000/' + field)
         assert resp.status_code == 404


### PR DESCRIPTION
#### What does this PR do?
Fix POST and PATCH endpoints to return data of record created and customized message of updated field respectively.
#### Description of Task to be completed?
* Add tests to test_views module to check that response data from post and patch endpoints returns the record created by user/client and a descriptive message of updated field respectively.
* Fix the POST endpoint so that when a red-flag record is created, the data representing the record is returned in the response.
* Fix the PATCH endpoint so that on successful update of either comment or location field, a customized and descriptive message is returned in the response

#### How should this be manually tested?
clone the repo, checkout the current branch i.e. bg-fix-post-patch-162407900 and run the application.(Following instructions in the README). Test the post and patch endpoints using any one of the methods specified in the README and check that the correct data is returned.
#### Any background context you want to provide?
The changes are in keeping with the feedback to ensure that on creating a record, the created record item is returned instead of just the id and that on updating a record, a more descriptive message that gives context of what has been updated is returned
#### What are the relevant pivotal tracker stories?
#162407900