### PR TITLE
#162422566 Add extra validations to the POST endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ first clone this repo to your machine
 
  ``` git clone git@github.com:Omulosi/iReporter.git ```
 
-then change the directory to the project by doing
+then change the directory to the project directory
 
 ``` cd iReporter ```
 
-then change to the develop branch
+then move to the develop branch
     ``` git checkout develop ```
 
 to make sure all the project dependencies are installed, create a virtual enviroment and install the packages there.
@@ -59,15 +59,27 @@ the project implements the following endpoints
 |POST | /red-flags | Creates a new red-flag record|
 |GET | /red-flags/<id>| Display a specific record given a ID|
 |DELETE | /red-flags/<id>| Deletes a specific record given an ID|
-|PATCH | /red-flags/<id>/location| Edits the location field of a red-flag
-record|
-| PATCH | /red-flags/<id>/comment| Edits the comment field of a red-flag
-record|
+|PATCH | /red-flags/<id>/location| Edits the location field of a red-flag record|
+| PATCH | /red-flags/<id>/comment| Edits the comment field of a red-flag record|
 
 The endpoints can be tested using Postman, [HTTPie](https://httpie.org/doc) (a command line http client), or curl.
 
+## Sample payload data for testing
+
+Below are sample payload data you can use to test the endpoints
+
+`{'location': '-1.2, 37'}`
+
+`{'comment': 'judges soliciting for bribes'}`
+
+Both are strings and can be passed in as key value pairs in API requests. Check below for examples.
+
+More sample payloads will be added as more endpoints get implemented
+
 ## Test Using **Postman** (Recommended)
-With the project running locally, use the Postman service to test the endpoints by prepending each endpoint in the table above to the base url `http://127.0.0.1:5000/`
+With the project running locally, use the Postman service to test the endpoints by prepending each endpoint in the table above to the base url `http://127.0.0.1:5000/`. 
+
+For endpoints that require user/client input, POstman provides an easy to use graphical interface for supplying the values as key-value pairs.
 
 ## Test Using HTTPie
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # iReporter API
 [![Build Status](https://travis-ci.com/Omulosi/iReporter.svg?branch=ch-configure-deploy-file-162371370)](https://travis-ci.com/Omulosi/iReporter)
-[![codecov](https://codecov.io/gh/Omulosi/iReporter/branch/bg-record-model-tests-162368299/graph/badge.svg)](https://codecov.io/gh/Omulosi/iReporter)
+[![codecov](https://codecov.io/gh/Omulosi/iReporter/branch/master/graph/badge.svg)](https://codecov.io/gh/Omulosi/iReporter)
 [![Maintainability](https://api.codeclimate.com/v1/badges/a99a88d28ad37a79dbf6/maintainability)](https://codeclimate.com/github/codeclimate/codeclimate/maintainability)
 
 

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -115,7 +115,7 @@ class UpdateSingleRedflag(Resource):
         Record.put(record)
         output = {}
         output['status'] = 200
-        output['data'] = [{"id": _id, "message": "Updated red-flag record's " + field}]
+        output['data'] = [{"id": _id, "message": field + ' has been successfully updated'}]
         return output, 200
 #
 # API resource routing

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -41,7 +41,7 @@ class CreateOrReturnRedflags(Resource):
         record.add_field('uri', uri)
         Record.put(record)
         output = {'status': 201,
-                  'data': [{"id": record.data_id, "message": "Created a red-flag record"}]
+                  'data': [record.serialize]
                  }
 
         return output, 201, {'Location': uri}

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -52,6 +52,9 @@ class CreateOrReturnRedflags(Resource):
         if not location or not comment:
             return raise_error(400, "Neither location nor comment should be empty")
         location = valid_location(location)
+        if location is None:
+            return raise_error(400, "Wrong input format for location. "
+                "Use 'lat, long' format. Ensure they are within a valid range")
         record = Record(location=data['location'],
                         comment=data['comment'])
         uri = url_for('v1.redflag', _id=record.data_id, _external=True)

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -10,7 +10,7 @@ from . import api_bp
 from .models import Record
 from .errors import raise_error
 
-class RedflagListAPI(Resource):
+class CreateOrReturnRedflags(Resource):
     """
     Implements methods for creating a record and returning a collection
     of records.
@@ -20,7 +20,7 @@ class RedflagListAPI(Resource):
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('comment', type=str, required=True, help='comment not provided')
         self.parser.add_argument('location', type=str, required=True, help='location not provided')
-        super(RedflagListAPI, self).__init__()
+        super(CreateOrReturnRedflags, self).__init__()
 
     def get(self):
         """
@@ -46,7 +46,7 @@ class RedflagListAPI(Resource):
 
         return output, 201, {'Location': uri}
 
-class RedflagAPI(Resource):
+class SingleRedflag(Resource):
     """
     Implements methods for manipulating a particular record
     """
@@ -83,7 +83,7 @@ class RedflagAPI(Resource):
         out['data'] = [{'id':_id, 'message': 'red-flag record deleted'}]
         return out
 
-class RedflagUpdateAPI(Resource):
+class UpdateSingleRedflag(Resource):
     """
     Updates the location or comment field of red-flag record
     """
@@ -91,7 +91,7 @@ class RedflagUpdateAPI(Resource):
         self.parser = reqparse.RequestParser()
         self.parser.add_argument('comment', type=str)
         self.parser.add_argument('location', type=str)
-        super(RedflagUpdateAPI, self).__init__()
+        super(UpdateSingleRedflag, self).__init__()
 
     def patch(self, _id, field):
         """
@@ -121,6 +121,6 @@ class RedflagUpdateAPI(Resource):
 # API resource routing
 #
 
-api_bp.add_resource(RedflagListAPI, '/red-flags', endpoint='redflags')
-api_bp.add_resource(RedflagAPI, '/red-flags/<_id>', endpoint='redflag')
-api_bp.add_resource(RedflagUpdateAPI, '/red-flags/<_id>/<field>', endpoint='update_redflag')
+api_bp.add_resource(CreateOrReturnRedflags, '/red-flags', endpoint='redflags')
+api_bp.add_resource(SingleRedflag, '/red-flags/<_id>', endpoint='redflag')
+api_bp.add_resource(UpdateSingleRedflag, '/red-flags/<_id>/<field>', endpoint='update_redflag')

--- a/app/tests/v1/test_views.py
+++ b/app/tests/v1/test_views.py
@@ -91,12 +91,23 @@ def test_get_one(client):
     assert resp.headers['Content-Type'] == 'application/json'
     assert b'data' in resp.data
     assert b'status' in resp.data
-    # Item not found
+    # Check that returned data has all fields and contains user input data
+    data = json.loads(resp.data.decode('utf-8'))
+    data = data['data'][0] # Returns a dictionary of data item
+    assert data.get('location') == '-1.23, 36.5'
+    assert data.get('comment') == 'crooked tendering processes'
+    assert type(data.get('type')) == str
+    assert type(data.get('status')) == str
+    assert type(data.get('createdBy')) == int
+    assert type(data.get('id')) == int
+    assert type(data.get('Images')) == list 
+    assert type(data.get('Videos')) == list 
+    # Item not found - ID out of range
     resp = client.get('/api/v1/red-flags/999')
     assert resp.status_code == 404
     assert resp.headers['Content-Type'] == 'application/json'
     # Invalid ID
-    resp = client.get('/api/v1/red-flags/data-id')
+    resp = client.get('/api/v1/red-flags/some-id')
     assert resp.status_code == 404
     assert resp.headers['Content-Type'] == 'application/json'
 

--- a/app/tests/v1/test_views.py
+++ b/app/tests/v1/test_views.py
@@ -8,6 +8,7 @@
 from app import create_app
 from instance.config import TestConfig
 from app.api.v1.models import Record as db
+from datetime import datetime
 import pytest
 import json
 
@@ -58,8 +59,17 @@ def test_post(client):
     assert resp.status_code == 201
     assert b'data' in resp.data
     assert b'status' in resp.data
+    # Check that returned data has all fields and contains user input data
     data = json.loads(resp.data.decode('utf-8'))
-    assert 'red-flag record' in data['data'][0]['message']
+    data = data['data'][0] # Returns a dictionary of data item
+    assert data.get('location') == '-1.23, 36.5'
+    assert data.get('comment') == 'crooked tendering processes'
+    assert type(data.get('type')) == str
+    assert type(data.get('status')) == str
+    assert type(data.get('createdBy')) == int
+    assert type(data.get('id')) == int
+    assert type(data.get('Images')) == list 
+    assert type(data.get('Videos')) == list 
     assert resp.mimetype == 'application/json'
     assert resp.headers['Location'] is not None
     # Missing fields in request
@@ -69,6 +79,7 @@ def test_post(client):
     assert resp.status_code ==  400
     resp = client.post('/api/v1/red-flags', data=None)
     assert resp.status_code ==  400
+
 
 def test_get_one(client):
     resp = client.post('/api/v1/red-flags', data=user_input)

--- a/app/tests/v1/test_views.py
+++ b/app/tests/v1/test_views.py
@@ -80,12 +80,28 @@ def test_post(client):
     assert type(data.get('Videos')) == list 
     assert resp.mimetype == 'application/json'
     assert resp.headers['Location'] is not None
-    # Missing fields in request
-    resp = client.post('/api/v1/red-flags', data={'location': '23,23'})
+    # Missing field(s) in request
+    resp = client.post('/api/v1/red-flags', data={'location': '23,53'})
     assert resp.status_code ==  400
     resp = client.post('/api/v1/red-flags', data={'comment': 'thief'})
     assert resp.status_code ==  400
     resp = client.post('/api/v1/red-flags', data=None)
+    assert resp.status_code ==  400
+    # input data should not be blank
+    resp = client.post('/api/v1/red-flags', data={'location': '', 'comment':''})
+    assert resp.status_code ==  400
+    # Too many input fields
+    resp = client.post('/api/v1/red-flags', data={'location': '20,20', 'comment':'corruption', '_type':'red-flag'})
+    assert resp.status_code ==  400
+    # Check latitude ranges
+    resp = client.post('/api/v1/red-flags', data={'location': '93,23'})
+    assert resp.status_code ==  400
+    resp = client.post('/api/v1/red-flags', data={'location': '-91,23'})
+    assert resp.status_code ==  400
+    # Check longitude ranges
+    resp = client.post('/api/v1/red-flags', data={'location': '34,181'})
+    assert resp.status_code ==  400
+    resp = client.post('/api/v1/red-flags', data={'location': '45,-183'})
     assert resp.status_code ==  400
 
 def test_get_one(client):

--- a/app/tests/v1/test_views.py
+++ b/app/tests/v1/test_views.py
@@ -12,7 +12,6 @@ from datetime import datetime
 import pytest
 import json
 
-
 @pytest.fixture
 def client():
     """
@@ -42,7 +41,6 @@ def test_get_all(client):
     assert resp.status_code == 200
     data = json.loads(resp.data.decode('utf-8'))
     assert len(data['data']) == 0
-
     resp = client.post('/api/v1/red-flags', data=user_input)
     resp = client.get('/api/v1/red-flags')
     assert resp.status_code == 200
@@ -50,6 +48,16 @@ def test_get_all(client):
     assert b'status' in resp.data
     data = json.loads(resp.data.decode('utf-8'))
     assert len(data['data']) == 1
+    data = json.loads(resp.data.decode('utf-8'))
+    data = data['data'][0] # Returns a dictionary of data item
+    assert data.get('location') == '-1.23, 36.5'
+    assert data.get('comment') == 'crooked tendering processes'
+    assert type(data.get('type')) == str
+    assert type(data.get('status')) == str
+    assert type(data.get('createdBy')) == int
+    assert type(data.get('id')) == int
+    assert type(data.get('Images')) == list 
+    assert type(data.get('Videos')) == list 
 
 def test_post(client):
     """
@@ -109,7 +117,6 @@ def test_get_one(client):
     resp = client.get('/api/v1/red-flags/some-id')
     assert resp.status_code == 404
     assert resp.headers['Content-Type'] == 'application/json'
-
 
 def test_delete_one(client):
     # create a red-flag to use for testing deletion

--- a/app/tests/v1/test_views.py
+++ b/app/tests/v1/test_views.py
@@ -80,7 +80,6 @@ def test_post(client):
     resp = client.post('/api/v1/red-flags', data=None)
     assert resp.status_code ==  400
 
-
 def test_get_one(client):
     resp = client.post('/api/v1/red-flags', data=user_input)
     assert resp.status_code == 201
@@ -136,7 +135,7 @@ def test_delete_one(client):
     assert resp.status_code == 404
     assert resp.headers['Content-Type'] == 'application/json'
 
-def test_patch_location_and_comment(client):
+def test_patch_location_or_comment(client):
     def update_field(field):
         resp = client.post('/api/v1/red-flags', data=user_input)
         assert resp.status_code == 201
@@ -153,7 +152,7 @@ def test_patch_location_and_comment(client):
         assert b'data' in resp.data
         assert b'status' in  resp.data
         data = json.loads(resp.data.decode('utf-8'))
-        assert 'Updated' in data['data'][0]['message']
+        assert data['data'][0]['message'] == field + ' has been successfully updated'
         # Item not present
         resp = client.patch('/api/v1/red-flags/10000/' + field)
         assert resp.status_code == 404


### PR DESCRIPTION
#### What does this PR do?
Adds extra validation logic to the method that handles the POST endpoint i.e. `CreateOrReturnRedflags` class of the `views` module
#### Description of Task to be completed?
* Add tests to check that only two input fields are needed: location and comment. Otherwise return an error response
* Add tests to check that the fields are not empty, otherwise return an error response
* Add tests to check that location field is within accepted ranges i.e. latitude is within +/- 90 degrees, and longitude +/- 180 degrees.
* Add logic to views module to ensure all the above tests pass
#### How should this be manually tested?
Clone this repository, checkout the ft-add-post-validation-162422566), and run the application following instructions in the README. Test the POST endpoint using Postman, passing all combinations of invalid data. You should see appropriate and descriptive error responses for any invalid input data, while only valid data will result in a successful request
#### Any background context you want to provide?
The validations should be able to cover all input scenarios, and return descriptive and informative error responses that inform user/client what went wrong and hence possible ways to correct it.
#### What are the relevant pivotal tracker stories?
#162422566