### PR TITLE
#162527813 fix patch comment endpoint

### DIFF
--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -138,7 +138,7 @@ class UpdateSingleRedflag(Resource):
             new_comment = comment_data.get('comment')
             if not new_comment:
                 return raise_error(400, 'comment field should not be empty')
-            record.location = new_comment
+            record.comment = new_comment
         Record.put(record)
         output = {}
         output['status'] = 200


### PR DESCRIPTION
#### What does this PR do?
Fix patch endpoint to return updated record
#### Description of Task to be completed?
Fix code section in the patch endpoint logic so that the records comment field is the one updated instead of the location field as previously done
#### How should this be manually tested?
clone the repo, run the application following instruction on README. Update the comment field and check that it successfully updates.
#### What are the relevant pivotal tracker stories?
#162527813