### PR TITLE
#162528231 fix views tests 

### DIFF
--- a/app/api/v1/models.py
+++ b/app/api/v1/models.py
@@ -14,8 +14,9 @@ class Model:
     """
     Base class for all database objects
     """
-    data_id = 0
-    _db = {} 
+    # These fields are private to this class
+    _id = 0
+    _db = {}
 
     def __init__(self):
         self.created = datetime.utcnow()
@@ -87,8 +88,12 @@ class Record(Model):
         self.video = [] if video is None else video
         self.user = user
         Model.__init__(self)
-        self.data_id = self.data_id + 1
-        Record.data_id = self.data_id
+        self._id = self.data_id + 1 # updates instance's id for each record
+        Record._id = self.data_id # stores current running count of IDs
+
+    @property
+    def data_id(self):
+        return self._id
 
     @property
     def serialize(self):

--- a/app/api/v1/models.py
+++ b/app/api/v1/models.py
@@ -88,8 +88,8 @@ class Record(Model):
         self.video = [] if video is None else video
         self.user = user
         Model.__init__(self)
-        self._id = self.data_id + 1 # updates instance's id for each record
-        Record._id = self.data_id # stores current running count of IDs
+        self._id = self.data_id + 1
+        Record._id = self.data_id
 
     @property
     def data_id(self):

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -132,7 +132,7 @@ class UpdateSingleRedflag(Resource):
             if not valid_location(new_location):
                 return raise_error(400, 'location field has invalid format')
             record.location = new_location
-            
+
         elif field == 'comment':
             comment_data = self.comment_parser.parse_args(strict=True)
             new_comment = comment_data.get('comment')
@@ -142,7 +142,7 @@ class UpdateSingleRedflag(Resource):
         Record.put(record)
         output = {}
         output['status'] = 200
-        output['data'] = [{"id": _id, "message": field + ' has been successfully updated'}]
+        output['data'] = [{"id": _id, "message": field + ' has been successfully updated', "data": record.serialize }]
         return output, 200
 #
 # API resource routing

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -138,7 +138,7 @@ class UpdateSingleRedflag(Resource):
             new_comment = comment_data.get('comment')
             if not new_comment:
                 return raise_error(400, 'comment field should not be empty')
-            record.location = new_comment
+            record.comment = new_comment
         Record.put(record)
         output = {}
         output['status'] = 200

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -142,7 +142,7 @@ class UpdateSingleRedflag(Resource):
         Record.put(record)
         output = {}
         output['status'] = 200
-        output['data'] = [{"id": _id, "message": field + ' has been successfully updated', "data": record.serialize }]
+        output['data'] = [{"id": _id, "message": field + ' has been successfully updated', "record": record.serialize }]
         return output, 200
 #
 # API resource routing

--- a/app/tests/v1/test_views.py
+++ b/app/tests/v1/test_views.py
@@ -51,13 +51,13 @@ def test_get_all(client):
     data = json.loads(resp.data.decode('utf-8'))
     data = data['data'][0] # Returns a dictionary of data item
     assert data.get('location') == '-1.23, 36.5'
-    assert data.get('comment') == 'crooked tendering processes'
+    assert data.get('comment') # comment field must be present
     assert type(data.get('type')) == str
     assert type(data.get('status')) == str
     assert type(data.get('createdBy')) == int
     assert type(data.get('id')) == int
-    assert type(data.get('Images')) == list 
-    assert type(data.get('Videos')) == list 
+    assert type(data.get('Images')) == list
+    assert type(data.get('Videos')) == list
 
 def test_post(client):
     """
@@ -71,13 +71,13 @@ def test_post(client):
     data = json.loads(resp.data.decode('utf-8'))
     data = data['data'][0] # Returns a dictionary of data item
     assert data.get('location') == '-1.23, 36.5'
-    assert data.get('comment') == 'crooked tendering processes'
+    assert data.get('comment') # comment field must be present
     assert type(data.get('type')) == str
     assert type(data.get('status')) == str
     assert type(data.get('createdBy')) == int
     assert type(data.get('id')) == int
-    assert type(data.get('Images')) == list 
-    assert type(data.get('Videos')) == list 
+    assert type(data.get('Images')) == list
+    assert type(data.get('Videos')) == list
     assert resp.mimetype == 'application/json'
     assert resp.headers['Location'] is not None
     # Missing field(s) in request
@@ -118,13 +118,13 @@ def test_get_one(client):
     data = json.loads(resp.data.decode('utf-8'))
     data = data['data'][0] # Returns a dictionary of data item
     assert data.get('location') == '-1.23, 36.5'
-    assert data.get('comment') == 'crooked tendering processes'
+    assert data.get('comment') # comment field must be present
     assert type(data.get('type')) == str
     assert type(data.get('status')) == str
     assert type(data.get('createdBy')) == int
     assert type(data.get('id')) == int
-    assert type(data.get('Images')) == list 
-    assert type(data.get('Videos')) == list 
+    assert type(data.get('Images')) == list
+    assert type(data.get('Videos')) == list
     # Item not found - ID out of range
     resp = client.get('/api/v1/red-flags/999')
     assert resp.status_code == 404
@@ -177,6 +177,7 @@ def test_patch_location_or_comment(client):
         assert b'status' in  resp.data
         data = json.loads(resp.data.decode('utf-8'))
         assert data['data'][0]['message'] == field + ' has been successfully updated'
+        assert data['data'][0]['record']
         # Item not present - ID out of range
         resp = client.patch('/api/v1/red-flags/10000/' + field)
         assert resp.status_code == 404
@@ -214,5 +215,3 @@ def test_patch_location_or_comment(client):
 
     update_field('location')
     update_field('comment')
-
-


### PR DESCRIPTION
#### What does this PR do?
Fixes test views
#### Description of Task to be completed?
Fix test views to only check that a comment field is present instead of checking for the comment string verbatim so that updating the comment wont require updates at multiple locations. Add record key to output response of patch endpoint and test for it
#### How should this be manually tested?
clone the repo, checkout the branch bg-fix-views-tests-162528231, run tests and see that all tests pass
#### What are the relevant pivotal tracker stories?
#162528231