### PR TITLE
#162675821 Fix patch and delete endpoints

### DIFF
--- a/app/api/v2/auth.py
+++ b/app/api/v2/auth.py
@@ -11,7 +11,7 @@ from flask_restful import Resource, reqparse
 from . import api_bp
 from .models import  User
 from .errors import raise_error
-from .utilities import valid_username, valid_email, valid_password
+from .utilities import valid_username, valid_email, valid_password, update_createdon
 
 
 class SignUp(Resource):
@@ -103,7 +103,7 @@ class Login(Resource):
         refresh_token = create_refresh_token(identity=username)
         user = {field_name: field_val for field_name, field_val
                      in user.items() if field_name != 'password_hash'}
-        user['createdon'] = user.get('createdon').strftime('%a, %d %b %Y %H:%M %p')
+        user = update_createdon(user)
         return {
             'status': 200,
             'data': [{'access_token': access_token,

--- a/app/api/v2/models.py
+++ b/app/api/v2/models.py
@@ -71,16 +71,16 @@ class Base(db.Model):
         return result
 
     @classmethod
-    def delete(cls, _id, user_id=None):
+    def delete(cls, _id):
         """
         Deletes a record
         """
-        if cls == Record and user_id:
-            query = "delete from records where id=%s and user_id=%s;"
-            cls.query(query, (_id, user_id))
-        if cls == User and not user_id:
+        if cls == Record:
+            query = "delete from records where id=%s;"
+        if cls == User:
             query = "delete from users where id=%s;"
-            cls.query(query, (_id,))
+        cls.query(query, (_id,))
+        cls.commit()
 
     @classmethod
     def update(cls, _id, field, data):
@@ -92,6 +92,7 @@ class Base(db.Model):
         if cls == User:
             query = "update users set {} = ".format(field)
         cls.query(query + " %s where id = %s", (data, _id))
+        cls.commit()
 
     @classmethod
     def get_last_inserted_id(cls):

--- a/app/api/v2/models.py
+++ b/app/api/v2/models.py
@@ -20,60 +20,46 @@ class Base(db.Model):
     def filter_by(cls, field, value):
         """
         field -> str
-        Takes a field by which to filter and returns all items
-        with the field specified
+        Takes a field and a value by which to filter
+        Returns a list of all matching items as dictionaries
+        in a list or an empty list
         """
-        result = []
         if cls == Record:
             query = """ select * from records where {} = %s;""".format(field)
         if cls == User:
             query = """ select * from users where {} = %s;""".format(field)
         cls.query(query, (value,))
-        items = cls.fetchall()
-        fields = [description[0] for description in cls.cursor.description
-                  if description[0] != 'user_id' if description[0] != 'password_hash']
-        if items:
-            result = [zip(fields, item) for item in items]
-        return [dict(elem) for elem in result]
+        return cls.fetchall()
 
     @classmethod
     def all(cls):
         """
-        Return all items from users or records
+        Return all items from users or records as a list of
+        dictionaries or an empty list
         """
-        result = []
         if cls == Record:
-            items = cls.get_all('records')
+            query = """select * from records order by createdon desc;"""
         if cls == User:
-            items = cls.get_all('users')
-        fields = [desc[0] for desc in cls.cursor.description if desc[0] != 'user_id'
-                  if desc[0] != 'password_hash']
-        if items:
-            result = [zip(fields, item) for item in items]
-        return [dict(elem) for elem in result]
+            query = """select * from records order by createdon desc;"""
+        cls.query(query)
+        return cls.fetchall()
 
     @classmethod
     def by_id(cls, item_id):
         """
         Query an item by id
         """
-        result = []
         if cls == Record:
             query = "select * from records where id = %s;"
         if cls == User:
             query = "select * from users where id = %s;"
         cls.query(query, (item_id,))
-        item = cls.fetchall()
-        if item:
-            fields = [desc[0] for desc in cls.cursor.description if desc[0] != 'user_id'
-                      if desc[0] != 'password_hash']
-            result = [dict(zip(fields, item))]
-        return result
+        return cls.fetchall()
 
     @classmethod
     def delete(cls, _id):
         """
-        Deletes a record
+        Deletes a data item with the specified id.
         """
         if cls == Record:
             query = "delete from records where id=%s;"
@@ -84,8 +70,9 @@ class Base(db.Model):
 
     @classmethod
     def update(cls, _id, field, data):
-        """ Given field(string) and data,
-        updates field with data
+        """ 
+        Given a field(string) and data,
+        updates field with data.
         """
         if cls == Record:
             query = "update records set {} = ".format(field)
@@ -103,7 +90,8 @@ class Base(db.Model):
         query = "select id from {} order by id desc limit 1;".format(table)
         cls.query(query)
         _id = cls.fetchall()
-        return _id
+        if _id:
+            return _id[0].get('id')
 
 class Record(Base):
 

--- a/app/api/v2/utilities.py
+++ b/app/api/v2/utilities.py
@@ -2,7 +2,7 @@
     app.api.v2.utilities
     ~~~~~~~~~~~~~~~~~~
 
-    General utility functions used for validating inputs
+    This module contains general utility functions
 
 """
 
@@ -61,3 +61,14 @@ def valid_password(password):
     """
     password = password.strip()
     return password if len(password) > 5 else None
+
+
+def update_createdon(data_item):
+    """
+    updates the createdon field's datetime data into
+    a string representation of the date.
+    Returns a new dictionary item with the field
+    updated
+    """
+    data_item['createdon'] = data_item['createdon'].strftime('%a, %d %b %Y %H:%M %p')
+    return data_item

--- a/app/db.py
+++ b/app/db.py
@@ -7,6 +7,7 @@
 """
 
 import psycopg2
+from psycopg2.extras import RealDictCursor
 from instance.config import Config
 
 class Model(object):
@@ -16,7 +17,7 @@ class Model(object):
     # use our connection values to establish a connection
     conn = psycopg2.connect(connect_str)
     # create a psycopg2 cursor that can execute queries
-    cursor = conn.cursor()
+    cursor = conn.cursor(cursor_factory=RealDictCursor)
 
     @classmethod
     def close_connection(cls):
@@ -42,21 +43,21 @@ class Model(object):
     @classmethod
     def by_username(cls, username):
         """
-        field -> str
-        Returns the record with the given username
+        Returns a user data item with the given username
+        as a dictionary.
         """
-        res = []
         query = """ select * from users where username = %s;"""
         cls.query(query, (username,))
-        items = cls.fetchall()
-        fields = [desc[0] for desc in cls.cursor.description]
-        if items:
-            res = [zip(fields, item) for item in items]
-        return [dict(elem) for elem in res][0] if res else {}
+        record = cls.fetchall()
+        return record[0] if record else {}
 
     @classmethod
     def comments(cls):
-        sql = "select comment from records order by createdOn desc;"
+        """
+        Returns list containing all comments each in a dictionary
+        format.
+        """ 
+        sql = "select comment from records order by createdon desc;"
         cls.query(sql)
         return cls.fetchall()
 


### PR DESCRIPTION
#### What does this PR do?
Fixes patch and delete endpoints to only delete records created by user doing the deleting and to  only update a record if user status is an admin
#### Description of Task to be completed?
* Add a validation decorator to the delete and patch endpoints to validate input data and ensure that:
     * A user can only delete the record he/she created
     * Only an admin can update a record's status
* Update the database model 
#### How should this be manually tested?
clone the repo, checkout the bg-fix-patch-delete-162675821 and run the application as indicated in the README. Ensure that the patch and deleted endpoints work as expected.
#### What are the relevant pivotal tracker stories?
#162675821